### PR TITLE
Update KIK-V page with new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Een moer is waardeloos zonder een bout, en evenzo is [Nuts](https://nuts.nl) waardeloos zonder een Bolt. “Bolt” is onze term voor een concrete toepassing van het [Nuts gedachtengoed](https://nuts.nl/manifest) en [open technologie](https://nuts-foundation.gitbook.io/) om een tastbare use-case in de zorg mogelijk te maken.
 
-Op deze pagina's verzamelt en beheert de Nuts community de specificaties van de diverse Bolts. De komende tijd zullen meerdere Bolts worden toegevoegd.
+Op deze pagina's verzamelt en beheert de Nuts community de specificaties van de diverse Bolts.
 

--- a/keteninformatie-kwaliteit-verpleeghuiszorg/kwaliteitsinformatie.md
+++ b/keteninformatie-kwaliteit-verpleeghuiszorg/kwaliteitsinformatie.md
@@ -1,3 +1,8 @@
-# Kwaliteitsinformatie
+# Keteninformatie kwaliteit verpleeghuiszorg (KIK-V)
 
-De specificaties voor keteninformatie kwaliteit verpleeghuiszorg zijn verhuist naar: [https://gitlab.com/data-en-techniek/explainers/implementatiegids-kik-v-met-een-nuts-node](https://gitlab.com/data-en-techniek/explainers/implementatiegids-kik-v-met-een-nuts-node)&#x20;
+De concept specificaties voor keteninformatie kwaliteit verpleeghuiszorg staan in [deze map](https://drive.google.com/drive/u/1/folders/1sEOiBuH3Az4ddibPsvdPGt9AoY3rJQFR).
+
+Aanvullend zijn ook in de map opgenomen:
+* De concept samenwerkingsafspraken tussen Nuts en KIK-V;
+* Notulen van de praktijkbeproeving van het samenwerkingsoverleg tussen Nuts en KIK-V;
+* Presentaties van KIK-V voor de Nuts community.


### PR DESCRIPTION
New spec is stored on the Google Drive. Link updates to these folders.