### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Bolts
+# Toepassingen op Nuts
 
-Een moer is waardeloos zonder een bout, en evenzo is [Nuts](https://nuts.nl) waardeloos zonder een Bolt. “Bolt” is onze term voor een concrete toepassing van het [Nuts gedachtengoed](https://nuts.nl/manifest) en [open technologie](https://nuts-foundation.gitbook.io/) om een tastbare use-case in de zorg mogelijk te maken.
+Een “Toepassing op Nuts” [Nuts](https://nuts.nl/documentatie/) is een specifieke toepassing die gebruik maakt van de Nuts-specificatie en waarover partijen aanvullende openbare eisen en specificaties hebben afgesproken. Omdat het Nuts-netwerk als vertrouwenslaag dient, is het geschikt voor vele toepassingen. Iedereen kan een toepassing op het Nuts netwerk maken. Een Toepassing op Nuts is dan ook een praktische toepassing van het [Nuts gedachtengoed](https://nuts.nl/manifest) en [open technologie](https://nuts-foundation.gitbook.io/) om een tastbare usecase in de zorg mogelijk te maken.
 
-Op deze pagina's verzamelt en beheert de Nuts community de specificaties van de diverse Bolts.
+In de pioniersfase van de Nuts-community hebben we de metafooren Nuts and Bolts gebruikt om de Nuts-specificatie (destijds “Nuts”) en de specifieke toepassingen ( destijds “Bolts”) te duiden. De term "Bolt" is vervangen door “Toepassing op Nuts” om juist de onafhankelijkheid van de toepassingen en de vertrouwenslaag op het internet en de daarmee gepaard gaande schaalbaarheid van de Nuts-specificatie te benadrukken. Ook was het voor nieuwe partijen die met de Nuts-specificatie aan de slag gingen, jargon dat afleidt van waar het over gaat. De term ‘Bolt’ wordt daarom in de nieuwe documentatie niet meer gebruikt. 
 
+Op deze pagina's verzamelt en beheert de Nuts community de specificaties van de Toepassingen op het Nuts-netwerk.


### PR DESCRIPTION
Bolts als terminologie gebruiken wij niet meer.  De webpagina: https://nuts.nl/documentatie/ is geüpdatet en verwijst naar deze pagina. Ook op deze pagina de terminologie aangepast.